### PR TITLE
docs: Correct the preposition reversed

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This action currently caches the following directories:
 ```
 
 > [!CAUTION]
-> You have to run this action _before_ `npm ci` because `npm ci` removes `node_modules` first. If you don't, this action will lose its effect.
+> You have to run this action _after_ `npm ci` like the above example because `npm ci` removes `node_modules` first. If you don't, this action will lose its effect.
 
 ## Contributing
 


### PR DESCRIPTION
> You have to run this action ___before___ `npm ci` because `npm ci` removes `node_modules` first. If you don't, this action will lose its effect.

↓

> You have to run this action ___after___ `npm ci` because `npm ci` removes `node_modules` first. If you don't, this action will lose its effect.

I made the mistake of reversing the preposition in #20. The example workflow is correct.